### PR TITLE
Bump/compiles with ghc 9.4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 servant-websockets.cabal
+dist-newstyle/
 *~

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,14 @@
+packages:
+    core
+    server
+    client
+    docs
+    examples
+    test
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell-servant/servant.git
+    tag: 2323906080e50fc2774cd1b43bc59548a90152ed
+    subdir:
+        servant-client-core

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,12 @@ packages:
     docs
     examples
     test
+
+-- NOTE: Waiting on a hackage release.
+-- SEE: https://github.com/haskell-servant/servant/issues/1636
+source-repository-package
+    type: git
+    location: https://github.com/haskell-servant/servant.git
+    tag: 3f6886ad2df62d05d11409d076baad947621fab4
+    subdir:
+        servant-docs

--- a/cabal.project
+++ b/cabal.project
@@ -5,10 +5,3 @@ packages:
     docs
     examples
     test
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell-servant/servant.git
-    tag: 2323906080e50fc2774cd1b43bc59548a90152ed
-    subdir:
-        servant-client-core

--- a/client/package.yaml
+++ b/client/package.yaml
@@ -41,4 +41,8 @@ library:
   - -fwarn-tabs
   - -Wincomplete-uni-patterns
   - -O2
-  - -eventlog
+
+when:
+  - condition: impl(ghc < 9.4)
+    ghc-options:
+    - -eventlog

--- a/client/package.yaml
+++ b/client/package.yaml
@@ -1,10 +1,10 @@
 # GENERATED HEADER START
 name:                servant-websockets-client
-version:             0.0.0.1
+version:             0.0.1
 github:              "simspace/servant-websockets"
-license:             BSD3
+license:             BSD-3-Clause
 author:              "Cary Robbins"
-maintainer:          "carymrobbins@gmail.com"
+maintainer:          "SimSpace Engineering"
 copyright:           "2019 SimSpace"
 category:            Web
 synopsis:            Client library for using websockets with servant

--- a/client/servant-websockets-client.cabal
+++ b/client/servant-websockets-client.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 90a69200bef6ed2e75c8a1b0af4acb87c83b692ec924ad3f290870679fde35c7
+-- hash: 90335b177172f85ce7cf5ffd715b3e601c6ea7d1d850cca967fed40a2e2afedd
 
 name:           servant-websockets-client
 version:        0.0.0.1
@@ -30,8 +30,17 @@ library
       Paths_servant_websockets_client
   hs-source-dirs:
       src
-  default-extensions: FlexibleContexts FlexibleInstances MultiParamTypeClasses RankNTypes RankNTypes ScopedTypeVariables TypeApplications TypeFamilies UndecidableInstances
-  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2 -eventlog
+  default-extensions:
+      FlexibleContexts
+      FlexibleInstances
+      MultiParamTypeClasses
+      RankNTypes
+      RankNTypes
+      ScopedTypeVariables
+      TypeApplications
+      TypeFamilies
+      UndecidableInstances
+  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2
   build-depends:
       base
     , binary
@@ -43,3 +52,5 @@ library
     , servant-websockets-core
     , websockets
   default-language: Haskell2010
+  if impl(ghc < 9.4)
+    ghc-options: -eventlog

--- a/client/servant-websockets-client.cabal
+++ b/client/servant-websockets-client.cabal
@@ -1,22 +1,22 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 90335b177172f85ce7cf5ffd715b3e601c6ea7d1d850cca967fed40a2e2afedd
+-- hash: 154a251461e91492d9e5118a264a32ef90b7436eef8d08b35c5526813629336d
 
 name:           servant-websockets-client
-version:        0.0.0.1
+version:        0.0.1
 synopsis:       Client library for using websockets with servant
 description:    Please see the README on GitHub at <https://github.com/simspace/servant-websockets#readme>
 category:       Web
 homepage:       https://github.com/simspace/servant-websockets#readme
 bug-reports:    https://github.com/simspace/servant-websockets/issues
 author:         Cary Robbins
-maintainer:     carymrobbins@gmail.com
+maintainer:     SimSpace Engineering
 copyright:      2019 SimSpace
-license:        BSD3
+license:        BSD-3-Clause
 build-type:     Simple
 
 source-repository head
@@ -27,6 +27,8 @@ library
   exposed-modules:
       Servant.WebSockets.Client
   other-modules:
+      Paths_servant_websockets_client
+  autogen-modules:
       Paths_servant_websockets_client
   hs-source-dirs:
       src

--- a/client/src/Servant/WebSockets/Client.hs
+++ b/client/src/Servant/WebSockets/Client.hs
@@ -14,6 +14,7 @@ import Servant.WebSockets.API (WebSocketApp)
 
 import qualified Data.ByteString.Lazy.Char8 as LazyChar8
 import qualified Network.WebSockets as WS
+import Data.Kind (Type)
 
 instance
   ( MonadReader ClientEnv m
@@ -28,7 +29,7 @@ instance
 type WebSocketClient m = WS.ClientApp () -> m ()
 
 hoistWebSocketClientMonad
-  :: Proxy (m :: * -> *)
+  :: Proxy (m :: Type -> Type)
   -> (forall x. mon x -> mon' x)
   -> Client mon WebSocketApp
   -> Client mon' WebSocketApp
@@ -38,7 +39,7 @@ webSocketClientWithRoute
   :: ( MonadIO m
      , MonadReader ClientEnv m
      )
-  => Proxy (m :: * -> *)
+  => Proxy (m :: Type -> Type)
   -> Request
   -> Client m WebSocketApp
 webSocketClientWithRoute _ req wsApp = do

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -22,4 +22,7 @@ library:
   - -fwarn-tabs
   - -Wincomplete-uni-patterns
   - -O2
-  - -eventlog
+  when:
+    - condition: impl(ghc < 9.4)
+      ghc-options:
+      - -eventlog

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,10 +1,10 @@
 # GENERATED HEADER START
 name:                servant-websockets-core
-version:             0.0.0.1
+version:             0.0.1
 github:              "simspace/servant-websockets"
-license:             BSD3
+license:             BSD-3-Clause
 author:              "Cary Robbins"
-maintainer:          "carymrobbins@gmail.com"
+maintainer:          "SimSpace Engineering"
 copyright:           "2019 SimSpace"
 category:            Web
 synopsis:            Core library for using websockets with servant

--- a/core/servant-websockets-core.cabal
+++ b/core/servant-websockets-core.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3544ea74934af59dda8b425ccfed8765c710062564bc0e86b51d79079e2edae6
+-- hash: 25ed3e5a6ee5c25a9320118bfc933b14c3fb289d304ebffe89c67a1d540d75e3
 
 name:           servant-websockets-core
 version:        0.0.0.1
@@ -30,7 +30,9 @@ library
       Paths_servant_websockets_core
   hs-source-dirs:
       src
-  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2 -eventlog
+  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2
   build-depends:
       base
   default-language: Haskell2010
+  if impl(ghc < 9.4)
+    ghc-options: -eventlog

--- a/core/servant-websockets-core.cabal
+++ b/core/servant-websockets-core.cabal
@@ -1,22 +1,22 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 25ed3e5a6ee5c25a9320118bfc933b14c3fb289d304ebffe89c67a1d540d75e3
+-- hash: 8dd25b5e09c02e3df04fe04811bff2b1c6522a6c71a41aaeffb786c530a2c812
 
 name:           servant-websockets-core
-version:        0.0.0.1
+version:        0.0.1
 synopsis:       Core library for using websockets with servant
 description:    Please see the README on GitHub at <https://github.com/simspace/servant-websockets#readme>
 category:       Web
 homepage:       https://github.com/simspace/servant-websockets#readme
 bug-reports:    https://github.com/simspace/servant-websockets/issues
 author:         Cary Robbins
-maintainer:     carymrobbins@gmail.com
+maintainer:     SimSpace Engineering
 copyright:      2019 SimSpace
-license:        BSD3
+license:        BSD-3-Clause
 build-type:     Simple
 
 source-repository head
@@ -27,6 +27,8 @@ library
   exposed-modules:
       Servant.WebSockets.API
   other-modules:
+      Paths_servant_websockets_core
+  autogen-modules:
       Paths_servant_websockets_core
   hs-source-dirs:
       src

--- a/docs/package.yaml
+++ b/docs/package.yaml
@@ -40,4 +40,7 @@ library:
   - -fwarn-tabs
   - -Wincomplete-uni-patterns
   - -O2
-  - -eventlog
+  when:
+    - condition: impl(ghc < 9.4)
+      ghc-options:
+      - -eventlog

--- a/docs/package.yaml
+++ b/docs/package.yaml
@@ -1,10 +1,10 @@
 # GENERATED HEADER START
 name:                servant-websockets-docs
-version:             0.0.0.1
+version:             0.0.1
 github:              "simspace/servant-websockets"
-license:             BSD3
+license:             BSD-3-Clause
 author:              "Cary Robbins"
-maintainer:          "carymrobbins@gmail.com"
+maintainer:          "SimSpace Engineering"
 copyright:           "2019 SimSpace"
 category:            Web
 synopsis:            Docs library for using websockets with servant

--- a/docs/servant-websockets-docs.cabal
+++ b/docs/servant-websockets-docs.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5c2372e63027b000d5ffbe85d0339934fbddcb05edd9563be69351c820fde642
+-- hash: 84ef1dd2a6f50bf24a2c365203d7c1c4ed761460f9b0d7ab99e2ae25013bf22e
 
 name:           servant-websockets-docs
 version:        0.0.0.1
@@ -30,8 +30,17 @@ library
       Paths_servant_websockets_docs
   hs-source-dirs:
       src
-  default-extensions: DataKinds FlexibleContexts FlexibleInstances KindSignatures OverloadedStrings PolyKinds ScopedTypeVariables TypeApplications TypeOperators
-  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2 -eventlog
+  default-extensions:
+      DataKinds
+      FlexibleContexts
+      FlexibleInstances
+      KindSignatures
+      OverloadedStrings
+      PolyKinds
+      ScopedTypeVariables
+      TypeApplications
+      TypeOperators
+  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2
   build-depends:
       base
     , bytestring
@@ -42,3 +51,5 @@ library
     , servant-websockets-core
     , text
   default-language: Haskell2010
+  if impl(ghc < 9.4)
+    ghc-options: -eventlog

--- a/docs/servant-websockets-docs.cabal
+++ b/docs/servant-websockets-docs.cabal
@@ -1,22 +1,22 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 84ef1dd2a6f50bf24a2c365203d7c1c4ed761460f9b0d7ab99e2ae25013bf22e
+-- hash: 71f8438ac1383a4ceca3765ac46de759c7029c0a61311c195509691eb64d73d9
 
 name:           servant-websockets-docs
-version:        0.0.0.1
+version:        0.0.1
 synopsis:       Docs library for using websockets with servant
 description:    Please see the README on GitHub at <https://github.com/simspace/servant-websockets#readme>
 category:       Web
 homepage:       https://github.com/simspace/servant-websockets#readme
 bug-reports:    https://github.com/simspace/servant-websockets/issues
 author:         Cary Robbins
-maintainer:     carymrobbins@gmail.com
+maintainer:     SimSpace Engineering
 copyright:      2019 SimSpace
-license:        BSD3
+license:        BSD-3-Clause
 build-type:     Simple
 
 source-repository head
@@ -27,6 +27,8 @@ library
   exposed-modules:
       Servant.WebSockets.Docs
   other-modules:
+      Paths_servant_websockets_docs
+  autogen-modules:
       Paths_servant_websockets_docs
   hs-source-dirs:
       src

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -49,7 +49,10 @@ library:
   - -Werror
   - -fwarn-tabs
   - -O0
-  - -eventlog
+  when:
+    - condition: impl(ghc < 9.4)
+      ghc-options:
+      - -eventlog
   source-dirs:
   - src
 

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -1,10 +1,10 @@
 # GENERATED HEADER START
 name:                servant-websockets-examples
-version:             0.0.0.1
+version:             0.0.1
 github:              "simspace/servant-websockets"
-license:             BSD3
+license:             BSD-3-Clause
 author:              "Cary Robbins"
-maintainer:          "carymrobbins@gmail.com"
+maintainer:          "SimSpace Engineering"
 copyright:           "2019 SimSpace"
 category:            Web
 synopsis:            Example server, client, and docs for servant-websockets

--- a/examples/servant-websockets-examples.cabal
+++ b/examples/servant-websockets-examples.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8d31792bf48130bbe1f33b489bdacc8934decc310e010f7d09ef3dee37a59d8f
+-- hash: 68aa050d081502bb1d5c6d6575b16b86c3cfbc59942bc6be76f5b508464e3369
 
 name:           servant-websockets-examples
 version:        0.0.0.1
@@ -31,8 +31,21 @@ library
       Paths_servant_websockets_examples
   hs-source-dirs:
       src
-  default-extensions: DataKinds DeriveAnyClass DeriveGeneric DerivingStrategies DerivingVia FlexibleInstances LambdaCase NamedFieldPuns OverloadedStrings ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators
-  ghc-options: -Wall -Werror -fwarn-tabs -O0 -eventlog
+  default-extensions:
+      DataKinds
+      DeriveAnyClass
+      DeriveGeneric
+      DerivingStrategies
+      DerivingVia
+      FlexibleInstances
+      LambdaCase
+      NamedFieldPuns
+      OverloadedStrings
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeOperators
+  ghc-options: -Wall -Werror -fwarn-tabs -O0
   build-depends:
       aeson
     , base
@@ -50,6 +63,8 @@ library
     , warp
     , websockets
   default-language: Haskell2010
+  if impl(ghc < 9.4)
+    ghc-options: -eventlog
 
 executable servant-websocket-example
   main-is: Main.hs
@@ -57,7 +72,20 @@ executable servant-websocket-example
       Paths_servant_websockets_examples
   hs-source-dirs:
       app
-  default-extensions: DataKinds DeriveAnyClass DeriveGeneric DerivingStrategies DerivingVia FlexibleInstances LambdaCase NamedFieldPuns OverloadedStrings ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators
+  default-extensions:
+      DataKinds
+      DeriveAnyClass
+      DeriveGeneric
+      DerivingStrategies
+      DerivingVia
+      FlexibleInstances
+      LambdaCase
+      NamedFieldPuns
+      OverloadedStrings
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson

--- a/examples/servant-websockets-examples.cabal
+++ b/examples/servant-websockets-examples.cabal
@@ -1,22 +1,22 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 68aa050d081502bb1d5c6d6575b16b86c3cfbc59942bc6be76f5b508464e3369
+-- hash: 78d6dcf9a8ad67d4c46eaaaddbcc25701f52d098ccbccee29455258b9271686f
 
 name:           servant-websockets-examples
-version:        0.0.0.1
+version:        0.0.1
 synopsis:       Example server, client, and docs for servant-websockets
 description:    Please see the README on GitHub at <https://github.com/simspace/servant-websockets#readme>
 category:       Web
 homepage:       https://github.com/simspace/servant-websockets#readme
 bug-reports:    https://github.com/simspace/servant-websockets/issues
 author:         Cary Robbins
-maintainer:     carymrobbins@gmail.com
+maintainer:     SimSpace Engineering
 copyright:      2019 SimSpace
-license:        BSD3
+license:        BSD-3-Clause
 build-type:     Simple
 
 source-repository head
@@ -28,6 +28,8 @@ library
       Servant.WebSockets.Examples.DeriveDocs
       Servant.WebSockets.Examples.MyExample
   other-modules:
+      Paths_servant_websockets_examples
+  autogen-modules:
       Paths_servant_websockets_examples
   hs-source-dirs:
       src
@@ -69,6 +71,8 @@ library
 executable servant-websocket-example
   main-is: Main.hs
   other-modules:
+      Paths_servant_websockets_examples
+  autogen-modules:
       Paths_servant_websockets_examples
   hs-source-dirs:
       app

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -1,10 +1,10 @@
 # GENERATED HEADER START
 name:                servant-websockets-server
-version:             0.0.0.1
+version:             0.0.1
 github:              "simspace/servant-websockets"
-license:             BSD3
+license:             BSD-3-Clause
 author:              "Cary Robbins"
-maintainer:          "carymrobbins@gmail.com"
+maintainer:          "SimSpace Engineering"
 copyright:           "2019 SimSpace"
 category:            Web
 synopsis:            Server library for using websockets with servant

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -41,4 +41,7 @@ library:
   - -fwarn-tabs
   - -Wincomplete-uni-patterns
   - -O2
-  - -eventlog
+  when:
+    - condition: impl(ghc < 9.4)
+      ghc-options:
+      - -eventlog

--- a/server/servant-websockets-server.cabal
+++ b/server/servant-websockets-server.cabal
@@ -1,22 +1,22 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 587e0c3c961f6848d1e7e63d18c1ed0c1c3756171b463770e36dc54d1ce8daf7
+-- hash: 540e3acfb517cc9a3fd0b901997510dc403e5d4904f83d390dfd18d02e30bce9
 
 name:           servant-websockets-server
-version:        0.0.0.1
+version:        0.0.1
 synopsis:       Server library for using websockets with servant
 description:    Please see the README on GitHub at <https://github.com/simspace/servant-websockets#readme>
 category:       Web
 homepage:       https://github.com/simspace/servant-websockets#readme
 bug-reports:    https://github.com/simspace/servant-websockets/issues
 author:         Cary Robbins
-maintainer:     carymrobbins@gmail.com
+maintainer:     SimSpace Engineering
 copyright:      2019 SimSpace
-license:        BSD3
+license:        BSD-3-Clause
 build-type:     Simple
 
 source-repository head
@@ -27,6 +27,8 @@ library
   exposed-modules:
       Servant.WebSockets.Server
   other-modules:
+      Paths_servant_websockets_server
+  autogen-modules:
       Paths_servant_websockets_server
   hs-source-dirs:
       src

--- a/server/servant-websockets-server.cabal
+++ b/server/servant-websockets-server.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 28f28b4323eaa1906d03246d4b8ea8efb2b5a85f67743a645e50392b1622b190
+-- hash: 587e0c3c961f6848d1e7e63d18c1ed0c1c3756171b463770e36dc54d1ce8daf7
 
 name:           servant-websockets-server
 version:        0.0.0.1
@@ -30,8 +30,17 @@ library
       Paths_servant_websockets_server
   hs-source-dirs:
       src
-  default-extensions: DataKinds AllowAmbiguousTypes FlexibleInstances LambdaCase MultiParamTypeClasses RankNTypes ScopedTypeVariables TypeApplications TypeFamilies
-  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2 -eventlog
+  default-extensions:
+      DataKinds
+      AllowAmbiguousTypes
+      FlexibleInstances
+      LambdaCase
+      MultiParamTypeClasses
+      RankNTypes
+      ScopedTypeVariables
+      TypeApplications
+      TypeFamilies
+  ghc-options: -Wall -Werror -fwarn-tabs -Wincomplete-uni-patterns -O2
   build-depends:
       base
     , bytestring
@@ -43,3 +52,5 @@ library
     , wai-websockets
     , websockets
   default-language: Haskell2010
+  if impl(ghc < 9.4)
+    ghc-options: -eventlog

--- a/server/src/Servant/WebSockets/Server.hs
+++ b/server/src/Servant/WebSockets/Server.hs
@@ -20,6 +20,7 @@ import Servant.Server.Internal.Router (Router, leafRouter)
 import Servant.WebSockets.API (WebSocketApp)
 
 import qualified Network.WebSockets as WS
+import Data.Kind (Type)
 
 instance HasServer WebSocketApp context where
   type ServerT WebSocketApp m = WebSocketServerT m
@@ -29,7 +30,7 @@ instance HasServer WebSocketApp context where
 type WebSocketServerT m = WS.PendingConnection -> m ()
 
 hoistWebSocketServerWithContext
-  :: Proxy (context :: [*])
+  :: Proxy (context :: [Type])
   -> (forall x. m x -> n x)
   -> ServerT WebSocketApp m
   -> ServerT WebSocketApp n

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.12
+resolver: lts-20.5
 
 packages:
 - ./core

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 545658
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/12.yaml
-    sha256: 26b807457213126d26b595439d705dc824dbb7618b0de6b900adc2bf6a059406
-  original: lts-14.12
+    sha256: a684cdbdf9304b325a503e0fe1d9648e9c18155ce4c7cfebbe8a7f93674e6295
+    size: 649106
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/5.yaml
+  original: lts-20.5

--- a/test/package.yaml
+++ b/test/package.yaml
@@ -51,6 +51,9 @@ tests:
     - -threaded
     - -rtsopts
     - '"-with-rtsopts=-N -T"'
-    - -eventlog
+    when:
+      - condition: impl(ghc < 9.4)
+        ghc-options:
+        - -eventlog
     source-dirs:
     - test

--- a/test/package.yaml
+++ b/test/package.yaml
@@ -1,10 +1,10 @@
 # GENERATED HEADER START
 name:                servant-websockets-test
-version:             0.0.0.1
+version:             0.0.1
 github:              "simspace/servant-websockets"
-license:             BSD3
+license:             BSD-3-Clause
 author:              "Cary Robbins"
-maintainer:          "carymrobbins@gmail.com"
+maintainer:          "SimSpace Engineering"
 copyright:           "2019 SimSpace"
 category:            Web
 synopsis:            Test suite for servant-websockets

--- a/test/servant-websockets-test.cabal
+++ b/test/servant-websockets-test.cabal
@@ -1,22 +1,22 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 52d027109c08ba2b8ee365ba8ce03d34ae6681250971f3d19a070b0c344cfc08
+-- hash: d13d8b01911e19b3ec10448560bb880367fc9ea1dd8a32c21df4e316e481adc1
 
 name:           servant-websockets-test
-version:        0.0.0.1
+version:        0.0.1
 synopsis:       Test suite for servant-websockets
 description:    Please see the README on GitHub at <https://github.com/simspace/servant-websockets#readme>
 category:       Web
 homepage:       https://github.com/simspace/servant-websockets#readme
 bug-reports:    https://github.com/simspace/servant-websockets/issues
 author:         Cary Robbins
-maintainer:     carymrobbins@gmail.com
+maintainer:     SimSpace Engineering
 copyright:      2019 SimSpace
-license:        BSD3
+license:        BSD-3-Clause
 build-type:     Simple
 
 source-repository head
@@ -29,6 +29,8 @@ test-suite servant-websockets-tests
   other-modules:
       DeriveDocsSpec
       ServantWebSocketsSpec
+      Paths_servant_websockets_test
+  autogen-modules:
       Paths_servant_websockets_test
   hs-source-dirs:
       test

--- a/test/servant-websockets-test.cabal
+++ b/test/servant-websockets-test.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 66d540f481d9b30bf991be5707c52d7562b3c7b9ef627a87876cbb046e54f27e
+-- hash: 52d027109c08ba2b8ee365ba8ce03d34ae6681250971f3d19a070b0c344cfc08
 
 name:           servant-websockets-test
 version:        0.0.0.1
@@ -32,8 +32,17 @@ test-suite servant-websockets-tests
       Paths_servant_websockets_test
   hs-source-dirs:
       test
-  default-extensions: DataKinds DeriveGeneric DerivingStrategies LambdaCase NamedFieldPuns OverloadedStrings ScopedTypeVariables TypeApplications TypeOperators
-  ghc-options: -Wall -fwarn-tabs -O0 -threaded -rtsopts "-with-rtsopts=-N -T" -eventlog
+  default-extensions:
+      DataKinds
+      DeriveGeneric
+      DerivingStrategies
+      LambdaCase
+      NamedFieldPuns
+      OverloadedStrings
+      ScopedTypeVariables
+      TypeApplications
+      TypeOperators
+  ghc-options: -Wall -fwarn-tabs -O0 -threaded -rtsopts "-with-rtsopts=-N -T"
   build-depends:
       async
     , base
@@ -52,3 +61,5 @@ test-suite servant-websockets-tests
     , warp
     , websockets
   default-language: Haskell2010
+  if impl(ghc < 9.4)
+    ghc-options: -eventlog

--- a/tools/gen-package-yaml-header
+++ b/tools/gen-package-yaml-header
@@ -11,11 +11,11 @@ packageYamlHeader() {
   cat <<HERE > "$tmp"
 # GENERATED HEADER START
 name:                servant-websockets-$subproject
-version:             0.0.0.1
+version:             0.0.1
 github:              "simspace/servant-websockets"
-license:             BSD3
+license:             BSD-3-Clause
 author:              "Cary Robbins"
-maintainer:          "carymrobbins@gmail.com"
+maintainer:          "SimSpace Engineering"
 copyright:           "2019 SimSpace"
 category:            Web
 synopsis:            $(synopsis "$subproject")


### PR DESCRIPTION
Also compiles with `ghc-9.2.5` and `ghc-8.10.7`.

The `-eventlog` flag is deprecated.

> Note that as of GHC 9.4 and later eventlog support is included in the RTS by default and the -eventlog is deprecated.
SOURCE: https://downloads.haskell.org/ghc/latest/docs/users_guide/phases.html#ghc-flag--eventlog

```
$ cabal build servant-websockets-core --enable-tests
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - servant-websockets-core-0.0.0.1 (lib) (first run)
Preprocessing library for servant-websockets-core-0.0.0.1..
Building library for servant-websockets-core-0.0.0.1..

on the commandline: error: [-Wdeprecated-flags, -Werror=deprecated-flags]
    -eventlog is deprecated: the eventlog is now enabled in all runtime system ways
```